### PR TITLE
Fix API version warning

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,5 @@
 name: FixChatColors
 version: 1.0
+api-version: 1.13
 author: Unlocked
 main: unlocked.fixchatcolors.FixChatColors


### PR DESCRIPTION
Spigot servers get the following warning when the plugin is installed on
the server

        [WARN] Initializing Legacy Material Support. Unless you have legacy plugins and/or data this is a bug!
        [WARN] Legacy plugin FixChatColors v1.0 does not specify an api-version.

This fixes that issues